### PR TITLE
Fix for MongoDB connection timeout

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -8,14 +8,19 @@ import pymongo
 import gtfs_realtime_pb2
 
 app = Flask(__name__)
-db = pymongo.Connection(os.environ['MONGO_URI']).hrt
 dthandler = lambda obj: obj.isoformat() if isinstance(obj, datetime) else None
 
-curDateTime  = datetime.utcnow() + timedelta(hours=-5)
-collectionPrefix = curDateTime.strftime('%Y%m%d')
+db = None
+curDateTime = None
+collectionPrefix = None
 
 @app.before_request
 def beforeRequest():
+	global db
+	global curDateTime
+	global collectionPrefix
+	
+	db = pymongo.Connection(os.environ['MONGO_URI']).hrt
 	curDateTime  = datetime.utcnow() + timedelta(hours=-5)
 	collectionPrefix = curDateTime.strftime('%Y%m%d')
 


### PR DESCRIPTION
The connection to MongoDB was timing out on the server, rendering the application useless. This fix renews the connection before ever request is processed.
