### PR TITLE
Use pytz to localize EST datetimes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ distribute==0.6.31
 geopy==0.95
 protobuf==2.5.0
 pymongo==2.4.1
+pytz==2013b
 wsgiref==0.1.2

--- a/scripts/process-ftp/HRTBus.py
+++ b/scripts/process-ftp/HRTBus.py
@@ -1,3 +1,4 @@
+import pytz
 from datetime import datetime, timedelta
 
 class Checkin:
@@ -6,7 +7,10 @@ class Checkin:
 		
 		# checkin time
 		# bug here if the file contains checkins from both 12/31/N and 1/1/N+1
-		self.time = datetime.strptime(parts[0] + ' ' + parts[1] + '/' + year, "%H:%M:%S %m/%d/%Y") + timedelta(hours=5)
+		local = pytz.timezone('US/Eastern')
+		naive = datetime.strptime(parts[0] + ' ' + parts[1] + '/' + year, "%H:%M:%S %m/%d/%Y")
+		local_dt = local.localize(naive, is_dst=None)
+		self.time = local_dt.astimezone(pytz.utc)
 		
 		# bus id
 		self.busId = int(parts[2])

--- a/scripts/process-ftp/HRTDatabase.py
+++ b/scripts/process-ftp/HRTDatabase.py
@@ -1,10 +1,11 @@
+import pytz
 from datetime import datetime, timedelta
 from pymongo import Connection
 
 class HRTDatabase:
-	def __init__(self, uri):
+	def __init__(self, uri, db):
 		self.client = Connection(uri)
-		self.database = self.client.hrt
+		self.database = self.client[db]
 	
 	# get bus route mappings that are not more than 30 minutes old
 	def getBusRouteMappings(self):
@@ -24,7 +25,7 @@ class HRTDatabase:
 		if self.database['checkins'].find().count() > 0:
 			lastTime = self.database['checkins'].find().sort("$natural", -1)[0]["time"]
 			lastBuses = self.database['checkins'].find({"time" : lastTime}).distinct("busId")
-			return {"time": lastTime, "busIds": lastBuses}
+			return {"time": lastTime.replace(tzinfo=pytz.UTC), "busIds": lastBuses}
 		return None
 	
 	def updateCheckins(self, checkins):

--- a/scripts/process-ftp/process-ftp.py
+++ b/scripts/process-ftp/process-ftp.py
@@ -62,7 +62,7 @@ def process(text):
 	checkinDocs.append(checkin.__dict__)
 
 c = config.load()
-db = HRTDatabase(c["db_uri"])
+db = HRTDatabase(c["db_uri"], c["db_name"])
 curTime = datetime.utcnow() + timedelta(hours=-5)
 
 busRouteMappings = db.getBusRouteMappings()

--- a/scripts/process-ftp/process-ftp.worker
+++ b/scripts/process-ftp/process-ftp.worker
@@ -1,6 +1,9 @@
 runtime 'python'
 exec "process-ftp.py"
 
+pip "pymongo"
+pip "pytz"
+
 file "HRTBus.py"
 file "HRTDatabase.py"
 file "config.py"

--- a/scripts/process-gtfs/HRTDatabase.py
+++ b/scripts/process-gtfs/HRTDatabase.py
@@ -2,9 +2,9 @@ from datetime import datetime, timedelta
 from pymongo import Connection, GEO2D
 
 class HRTDatabase:
-	def __init__(self, uri):
+	def __init__(self, uri, db):
 		self.client = Connection(uri)
-		self.database = self.client.hrt
+		self.database = self.client[db]
 
 	def removeOldGTFS(self, date):
 		print "Removing Old GTFS Data"

--- a/scripts/process-gtfs/process-gtfs.worker
+++ b/scripts/process-gtfs/process-gtfs.worker
@@ -2,6 +2,7 @@ runtime 'python'
 exec "process-gtfs.py"
 
 pip "pymongo"
+pip "pytz"
 
 file "HRTDatabase.py"
 file "config.py"


### PR DESCRIPTION
Use pytz to localize EST instead of manually changing the hour to avoid DST issues. Close #33.
