### PR TITLE
Stop Time Id should always be scheduled stop id

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -224,7 +224,6 @@ def getBusesAtStop(stopId):
 				stop['busId'] = checkin['busId']
 				stop['busPosition'] = checkin['location']
 				stop['busCheckinTime'] = checkin['time']
-				stop['_id'] = str(checkin['_id'])
 				break
 			except KeyError:
 				pass


### PR DESCRIPTION
The checkin id changes constantly. The scheduled stop time id is constant and should be used always.
