### PR TITLE
Add api for stop info by id

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -142,7 +142,7 @@ def vehiclePosition():
 @app.route('/api/')
 @support_jsonp
 def getApiInfo():
-    return json.dumps({'version': '0.3', 'dbHost': db.connection.host, 'curDateTime': curDateTime, 'collectionPrefix': collectionPrefix}, default=dthandler)
+    return json.dumps({'version': '0.4', 'dbHost': db.connection.host, 'curDateTime': curDateTime, 'collectionPrefix': collectionPrefix}, default=dthandler)
 
 @app.route('/api/routes/active/')
 @support_jsonp
@@ -186,6 +186,16 @@ def getStopsNear(lat, lng):
         outboundRoutes = db['gtfs_' + collectionPrefix].find({"stop_id": stop['stopId'], "direction_id": 0}).distinct('route_id')
         stop['inboundRoutes'] =  list(db['routes_' + collectionPrefix].find({'route_id': {'$in': inboundRoutes}}, fields={'_id': False}).sort('route_id'))
         stop['outboundRoutes'] = list(db['routes_' + collectionPrefix].find({'route_id': {'$in': outboundRoutes}}, fields={'_id': False}).sort('route_id'))
+    return json.dumps(stops)
+
+@app.route('/api/stops/id/<path:stopIds>/')
+@support_jsonp
+def getStopsById(stopIds):
+    ids = map(int, filter(None, stopIds.split('/')))
+    stops = db['stops_' + collectionPrefix].find({'stopId': {'$in': ids}})
+    stops = list(stops)
+    for stop in stops:
+        stop['_id'] = str(stop['_id'])
     return json.dumps(stops)
 
 @app.route('/api/stop_times/<int:routeId>/<int:stopId>/')


### PR DESCRIPTION
This API call allows a user of the bus finder app to enter a stop by id. The app uses this API call to get the complete stop info from just the stop id. The complete stop info is then displayed to the user (stop name and location) along with the upcoming arrivals.
