### PR TITLE
Pad stop id from FTP file with zeros

### DIFF
--- a/scripts/process-ftp/HRTBus.py
+++ b/scripts/process-ftp/HRTBus.py
@@ -29,4 +29,4 @@ class Checkin:
         if len(parts) == 10:
             self.routeId = int(parts[7])
             self.direction = int(parts[8]) - 1
-            self.stopId = parts[9]
+            self.stopId = parts[9].zfill(4)


### PR DESCRIPTION
Stop id in GTFS are all exactly 4 charaters long, padded with zeros.
